### PR TITLE
fix agentTarget call conventions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty-puppet-xp",
-  "version": "0.3.6",
+  "version": "0.3.17",
   "description": "Puppet XP for Wechaty",
   "directories": {
     "test": "tests"
@@ -64,7 +64,7 @@
   "dependencies": {
     "cuid": "^2.1.8",
     "faker": "^5.5.3",
-    "frida-sidecar": "^0.12.8",
+    "frida-sidecar": "^0.13.2",
     "typed-emitter": "^1.3.1"
   },
   "publishConfig": {

--- a/src/init-agent-script.js
+++ b/src/init-agent-script.js
@@ -285,11 +285,14 @@ const sendMsgNativeFunction = (() => {
   const asmNativeFunction = new NativeFunction(asmSendMsg, 'void', ['pointer', 'pointer'])
 
   const sendMsg = (
-    talkerIdPtr,
-    contentPtr,
+    talkerId,
+    content,
   ) => {
-    const talkerId  = talkerIdPtr.readUtf16String()
-    const content   = contentPtr.readUtf16String()
+    const talkerIdPtr = Memory.alloc(talkerId.length * 2 + 1)
+    const contentPtr  = Memory.alloc(content.length * 2 + 1)
+
+    talkerIdPtr.writeUtf16String(talkerId)
+    contentPtr.writeUtf16String(content)
 
     const sizeOfStringStruct = Process.pointerSize * 3 // + 0xd
 

--- a/src/wechat-sidecar.ts
+++ b/src/wechat-sidecar.ts
@@ -22,7 +22,6 @@ import {
   Call,
   Hook,
   ParamType,
-  RetType,
   Ret,
 
   agentTarget,
@@ -38,26 +37,21 @@ const initAgentScript = fs.readFileSync(require.resolve(
 class WeChatSidecar extends SidecarBody {
 
   @Call(agentTarget('getMyselfInfoFunction'))
-  @RetType('pointer')
   getMyselfInfo ():Promise<string> { return Ret() }
 
   @Call(agentTarget('getChatroomMemberInfoFunction'))
-  @RetType('pointer')
   getChatroomMemberInfo ():Promise<string> { return Ret() }
 
   @Call(agentTarget('getWechatVersionFunction'))
-  @RetType('bool')
   getWeChatVersion ():Promise<Boolean> { return Ret() }
 
   @Call(agentTarget('getContactNativeFunction'))
-  @RetType('pointer')
   getContact ():Promise<string> { return Ret() }
 
   @Call(agentTarget('sendMsgNativeFunction'))
-  @RetType('void')
   sendMsg (
-    @ParamType('pointer', 'Utf16String') contactId: string,
-    @ParamType('pointer', 'Utf16String') text: string,
+    contactId: string,
+    text: string,
   ): Promise<string> { return Ret(contactId, text) }
 
   @Hook(agentTarget('recvMsgNativeCallback'))


### PR DESCRIPTION
1. remove all `@ParamType` from `agentTarget`s
2. remove all `@RetType` from `agentTarget`s
3. change `sendMsg` in `initAgentScript` to use JavaScript values 

Fix #8 